### PR TITLE
Fix grammar in help :map-operator

### DIFF
--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -774,7 +774,7 @@ otherwise it is interpreted as two key presses:
 1.11 MAPPING AN OPERATOR				*:map-operator*
 
 An operator is used before a {motion} command.  To define your own operator
-you must create mapping that first sets the 'operatorfunc' option and then
+you must create a mapping that first sets the 'operatorfunc' option and then
 invoke the |g@| operator.  After the user types the {motion} command the
 specified function will be called.
 


### PR DESCRIPTION
Minot grammar change to `runtime/doc/map.txt`:

Before:
"To define your own operator you must create mapping [...]"

After:

"To define your own operator you must create a mapping [...]"